### PR TITLE
Consume apis

### DIFF
--- a/app/controllers/api/v1/backgrounds_controller.rb
+++ b/app/controllers/api/v1/backgrounds_controller.rb
@@ -1,0 +1,23 @@
+class Api::V1::BackgroundsController < ApplicationController
+
+  def index
+    location = params[:location]
+
+    conn = Faraday.new(
+      url: (ENV['UNSPLASH_URL'].to_s),
+      params: { client_id: (ENV['UNSPLASH_ACCESS_KEY']) }
+    )
+
+    location_json = conn.get('/search/photos?') do |req|
+      req.params[:query] = location
+      req.params[:per_page] = 1
+    end
+
+    picture_data = JSON.parse(location_json.body, symbolize_names: true)
+
+    picture_poro = PicturePoro.new(picture_data, location)
+
+    render json: PictureSerializer.new(picture_poro).serializable_hash.to_json
+
+  end
+end

--- a/app/controllers/api/v1/forecast_controller.rb
+++ b/app/controllers/api/v1/forecast_controller.rb
@@ -1,0 +1,42 @@
+class Api::V1::ForecastController < ApplicationController
+
+  def index
+    location = params[:location]
+
+
+    conn = Faraday.new(
+      url: (ENV['MAP_QUEST_URL'].to_s),
+      params: { key: (ENV['MAP_QUEST_API_KEY']) }
+    )
+
+    location_json = conn.get('/geocoding/v1/address') do |req|
+      req.params[:location] = location
+    end
+
+    location_data = JSON.parse(location_json.body, symbolize_names: true)
+    location_coordinates = LocationPoro.new(location_data)
+
+
+    #Call out to open weather api with lat and lng
+
+    conn = Faraday.new(
+      url: (ENV['OPEN_WEATHER_MAP_URL'].to_s),
+      params: { appid: (ENV['OPEN_WEATHER_MAP_API_KEY']) }
+    )
+
+    weather_json = conn.get('/data/2.5/onecall') do |req|
+      req.params[:lat] = location_coordinates.lat
+      req.params[:lon] = location_coordinates.lon
+      req.params[:units] = 'imperial'
+    end
+
+    weather_data = JSON.parse(weather_json.body, symbolize_names: true)
+
+
+    #turn weather_data into poro and serialize for the FE
+
+    weather_poro = WeatherPoro.new(weather_data)
+
+    render json: WeatherSerializer.new(weather_poro).serializable_hash.to_json
+  end
+end

--- a/app/poros/location_poro.rb
+++ b/app/poros/location_poro.rb
@@ -1,0 +1,8 @@
+class LocationPoro
+attr_reader :lat, :lon
+
+  def initialize(data)
+    @lat = data[:results].first[:locations].first[:latLng][:lat]
+    @lon = data[:results].first[:locations].first[:latLng][:lng]
+  end
+end

--- a/app/poros/picture_poro.rb
+++ b/app/poros/picture_poro.rb
@@ -1,0 +1,9 @@
+class PicturePoro
+  attr_reader :picture_url, :location, :source
+
+  def initialize(data, location)
+    @picture_url = data[:results].first[:urls][:regular]
+    @location = location
+    @source = 'unsplash.com'
+  end
+end

--- a/app/poros/weather_poro.rb
+++ b/app/poros/weather_poro.rb
@@ -1,0 +1,55 @@
+class WeatherPoro
+  attr_reader :current_weather, :daily_weather, :hourly_weather
+
+  def initialize(data)
+    @data = data
+    @daily_data = data[:daily].first(5)
+    @hourly_data = data[:hourly].first(8)
+  end
+
+  def current_weather
+    current_weather = {
+      datetime: Time.at(@data[:current][:dt]),
+      sunrise: Time.at(@data[:current][:sunrise]),
+      sunset: Time.at(@data[:current][:sunset]),
+      temp: @data[:current][:temp],
+      feels_like: @data[:current][:feels_like],
+      humidity: @data[:current][:humidity],
+      uvi: @data[:current][:uvi],
+      visibility: @data[:current][:visibility],
+      conditions: @data[:current][:weather].first[:description],
+      icon: @data[:current][:weather].first[:icon]
+    }
+  end
+
+  def daily_weather
+    daily = @daily_data.map do |data|
+      {
+        date: Time.at(data[:dt]),
+        sunrise: Time.at(data[:sunrise]),
+        sunset: Time.at(data[:sunset]),
+        max_temp: (data[:temp][:max]),
+        min_temp: (data[:temp][:min]),
+        conditions: data[:weather].first[:description],
+        icon: data[:weather].first[:icon]
+      }
+    end
+  end
+
+  def hourly_weather
+    hourly = @hourly_data.map do |data|
+      {
+        time: Time.at(data[:dt]),
+        temp: (data[:temp]),
+        wind_speed: data[:wind_speed],
+        wind_direction: data[:wind_deg],
+        conditions: data[:weather].first[:description],
+        icon: data[:weather].first[:icon]
+      }
+    end
+  end
+
+  def convert_K_to_C(temp)
+    ((temp - 273.15) * 9/5 + 32).round(1)
+  end
+end

--- a/app/serializers/picture_serializer.rb
+++ b/app/serializers/picture_serializer.rb
@@ -1,0 +1,7 @@
+class PictureSerializer
+  include FastJsonapi::ObjectSerializer
+  set_id { nil }
+  set_type :image
+
+  attributes :picture_url, :location, :source
+end

--- a/app/serializers/weather_serializer.rb
+++ b/app/serializers/weather_serializer.rb
@@ -1,0 +1,7 @@
+class WeatherSerializer
+  include FastJsonapi::ObjectSerializer
+  set_id { nil }
+  set_type :forecast
+
+  attributes :current_weather, :daily_weather, :hourly_weather
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,7 @@ require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
+require 'date'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/requests/api/v1/backgrounds/request_spec.rb
+++ b/spec/requests/api/v1/backgrounds/request_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+describe 'exposes /api/v1/backgrounds?location=denver,co', type: :request do
+  it 'accepts location as query params' do
+    location = 'denver,co'
+    get "/api/v1/backgrounds?location=#{location}"
+  end
+end 

--- a/spec/requests/api/v1/forecast/request_spec.rb
+++ b/spec/requests/api/v1/forecast/request_spec.rb
@@ -1,0 +1,3 @@
+require 'rails_helper'
+
+describe ''

--- a/spec/requests/api/v1/location/request_spec.rb
+++ b/spec/requests/api/v1/location/request_spec.rb
@@ -5,4 +5,9 @@ describe 'exposes /api/v1/forecast?location=denver,co', type: :request do
     location = 'denver,co'
     get "/api/v1/forecast?location=#{location}"
   end
+
+  it 'parses location data' do
+    location = 'denver,co'
+    get "/api/v1/forecast?location=#{location}"
+  end
 end

--- a/spec/requests/api/v1/location/request_spec.rb
+++ b/spec/requests/api/v1/location/request_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+describe 'exposes /api/v1/forecast?location=denver,co', type: :request do
+  it 'accepts location as query params' do
+    location = 'denver,co'
+    get "/api/v1/forecast?location=#{location}"
+  end
+end


### PR DESCRIPTION
Consumes map quest, open weather, and unsplash apis. 

factors JSON responses into POROs 
> All done on controller, MUST BE REFACTORED!

Serializes JSON payloads for forecast and background endpoints. 